### PR TITLE
Supporting updated shelljs property usage

### DIFF
--- a/lib/pdftotext.js
+++ b/lib/pdftotext.js
@@ -35,7 +35,7 @@ function pdftotext (filename, options) {
     self.add_options(['-']);
     var child = shell.exec('pdftotext ' + self.options.additional.join(' '));
     if (child.code === 0) {
-      return child.output;
+      return child.stdout;
     }
     else {
       if (!shell.which('pdftotext')) {


### PR DESCRIPTION
Output property has been depreacted in shelljs as it seems and replaced with stdout and stderr
Fixes #4 