### PR TITLE
Package dependencies include a safer version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "mocha": "*",
-    "jscoverage": ">=0.3.5"
+    "mocha": "~3.0.2",
+    "jscoverage": "~0.6.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Making sure we don't just allow any version, as well as bumping the jscoverage required version.
