### PR TITLE
Refactoring for 'this' enabled arrow functions

### DIFF
--- a/build/pdftotext.js
+++ b/build/pdftotext.js
@@ -14,17 +14,14 @@ function pdftotext(filename, options) {
     var _this = this;
 
     if (_typeof(optionArray.length) !== undefined) {
-      (function () {
-        var self = _this;
-        optionArray.forEach(function (el) {
-          if (el.indexOf(' ') > 0) {
-            var values = el.split(' ');
-            self.options.additional.push(values[0], values[1]);
-          } else {
-            self.options.additional.push(el);
-          }
-        });
-      })();
+      optionArray.forEach(function (el) {
+        if (el.indexOf(' ') > 0) {
+          var values = el.split(' ');
+          _this.options.additional.push(values[0], values[1]);
+        } else {
+          _this.options.additional.push(el);
+        }
+      });
     }
     return this;
   };

--- a/lib/pdftotext.js
+++ b/lib/pdftotext.js
@@ -8,13 +8,12 @@ function pdftotext (filename, options) {
 
   pdftotext.prototype.add_options = function(optionArray) {
     if (typeof optionArray.length !== undefined) {
-        let self = this;
-        optionArray.forEach(function(el) {
+        optionArray.forEach( el => {
           if (el.indexOf(' ') > 0) {
             let values = el.split(' ');
-            self.options.additional.push(values[0], values[1]);
+            this.options.additional.push(values[0], values[1]);
           } else {
-            self.options.additional.push(el);
+            this.options.additional.push(el);
           }
         });
     }


### PR DESCRIPTION
More ES6 support with clean arrow functions that to not require a special handling for `this`.